### PR TITLE
Add vertex coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ matplotlib.pyplot.imshow(img)
 
 pyplot.show();
 ```
+![img](http://i.imgur.com/nCNkQWZ.png)
 
 ##Object Tracker Usage##
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ sudo apt-get update
 sudo apt-get install libglfw3-dev
 ```
 
-##Python Wrapper##
-Probably the easiest way to use this package is with the python wrapper. (`ros_camera_sim.py`). This wraps the OpenRAVE plugin and handles the update thread, etc. Here's how to use it:
+##Python Wrappers##
+Probably the easiest way to use this package is with one of the python wrappers. (`ros_camera_sim.py` and `interface_wrapper.py`). This  wraps the OpenRAVE plugin and handles the update thread, etc. Here's how to use it:
 
+###Ros Camera Sim###
 ```python
 # Create a simulated camera in the given environment
 camera = RosCameraSim(env)
@@ -28,50 +29,26 @@ camera.start('/head/kinect2/qhd')
 # Add or remove bodies from the environment
 camera.add_body(my_body);
 ```
-
 The images/pointclouds get published to ROS.
 
 
-##Ros Camera Usage##
-After initializing openrave, you can create a simulated ROS camera using this package. Here's a simple script for doing that:
+###Non-ROS Wrapper###
 ```python
-# Load some objects and set them up in the environment
-env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/bowl.kinbody.xml')
-env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/fuze_bottle.kinbody.xml')
-bowl = env.GetKinBody('bowl')
-fuze = env.GetKinBody('fuze_bottle')
-tf = fuze.GetTransform()
-tf[0:3, 3] = numpy.array([0, 0, 1])
-fuze.SetTransform(tf)
+# Initialize the camera
+camera = interface_wrapper.SimCamera(env, transform=tf,
+                 fx=529, fy=525, cx=328, cy=267, near=0.01, far=10.0, 
+                 width=640, height=480)
+                 
+# Add the bodies to the camera renderer
+camera.add_body(my_body)
+# This is now a W x H x 3 numpy array filled with bytes
+img = camera.render()
+````
+You can use the camera to query information about the scene like occlusion, for instance.
 
-# Create the sensor
-sensor = openravepy.RaveCreateSensor(env, 'rave_to_ros_camera')
-# Set its intrinsics (fx, fy, cx, cy, near, far)
-sensor.SendCommand('setintrinsic 529 525 328 267 0.01 10')
-# And its resolution in pixels
-sensor.SendCommand('setdims 640 480')
-# Set up the ROS camera. The arguments are
-# Node name -- the name of the ROS node to use. Put "~" for a private node
-# Depth image name -- the name of the depth image to publish
-# Color image name -- the name of the color image to publish
-# Point cloud name -- the name of the point cloud to publish
-# tf frame name -- the name of the camera TF frame to publish
-# base frame name -- what frame in TF is the camera in?
-sensor.SendCommand('initialize ~ /sim/depth /sim/color /sim/points sim_camera world')
-#Initialize the sensor. Right now the size of the sensor can't be changed after you do this.
-# It will also open up an annoying opengl window just to get context.
-sensor.Configure(openravepy.Sensor.ConfigureCommand.PowerOn)
-# Add bodies to render with the given (r, g, b) colors
-sensor.SendCommand('addbody bowl 255 0 0')
-sensor.SendCommand('addbody fuze_bottle 0 255 0')
-# You can also set the sensor's extrinsic transform
-sensor.SetTransform([...])
-# This is how you make it render a frame (the argument is meaningless). Call this again and again to get more images.
-sensor.SimulationStep(0.01)
-```
-The images will be published through a ROS interface. A point cloud will also be published.
+##Simple Occlusion Example##
 
-##Occlusion Renderer Usage##
+Here is a script for determining how many pixels of a specific object are visible to the camera.
 
 ```python
 # Load some objects and set them up in the environment
@@ -110,6 +87,99 @@ img = data.imagedata
 matplotlib.pyplot.imshow(img)
 ```
 ![image](https://camo.githubusercontent.com/1ffdf9d3c652d0d8e5ff2ffdcb99b28824b27eb0/687474703a2f2f692e696d6775722e636f6d2f7a61566576354a2e706e67)
+
+
+##Advanced Usage##
+It's also possible to directly modify the data that's being drawn. The renderer supports vertex coloring, and allows you to modify the position of vertices.
+
+```python
+"""Loads up an environment, attaches a viewer, loads a scene, and renders 
+images using the advanced interface.
+"""
+import openravepy
+import matplotlib
+import random
+from matplotlib import pyplot
+from openravepy import *
+from offscreen_render import interface_wrapper
+from mpl_toolkits.mplot3d import Axes3D
+
+env = Environment() # create openrave environment
+
+# Load some objects and set them up in the environment
+env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/bowl.kinbody.xml')
+env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/fuze_bottle.kinbody.xml')
+bowl = env.GetKinBody('bowl')
+fuze = env.GetKinBody('fuze_bottle')
+
+# Set the object positions
+tf = fuze.GetTransform()
+tf[0:3, 3] = numpy.array([0.3, 0, 0.5])
+bowl.SetTransform(tf)
+
+# Position the camera
+tf[0:3, 3] = numpy.array([0.1, 0, -0.2])
+
+# Initialize the camera
+camera = interface_wrapper.SimCamera(env, transform=tf,
+                 fx=529, fy=525, cx=328, cy=267, near=0.01, far=10.0, 
+                 width=640, height=480)
+                 
+# Add the bodies to the camera renderer
+camera.add_body(fuze)
+camera.add_body(bowl)
+
+# Now we're going to query some values that the renderer is using
+# internally to render the objects. Each kinbody has some number of
+# links and some number of geometries for each link. This fuze bottle
+# has one link and two geometries per link. Apparently geometry 0 is empty
+# for the fuze bottle, and geometry 1 has the actual data. We just need
+# to pass in the link and geometry index to get the data associated with
+# this mesh. Note that the OpenRAVE collision meshes are used here,
+# not the visual meshes! Also note that these functions are pretty slow,
+# so use them sparingly.
+# Mesh positions are stored as a flat array of x, y, z values
+positions = camera.get_link_mesh_positions(fuze, 0, 1)
+# Mesh colors are stored as a flat array of r, g, b values
+colors = camera.get_link_mesh_colors(fuze, 0, 1)
+# The triangle index is a flat array of unsigned short values. Each group
+# of three values corresponds to a triangle in the mesh.
+indices = camera.get_link_mesh_indices(fuze, 0, 1)
+
+# Print the values to see what they are!
+print 'vertex position buffer: '
+print positions
+print 'vertex color buffer: '
+print colors
+print 'triangle index buffer: '
+print indices
+
+
+# Now we're going to randomize the positions and colors
+num_colors = colors.shape
+num_positions = positions.shape
+
+# Add 1 cm of random noise to the positions
+for i in xrange(0, num_positions[0]):
+    positions[i] += random.random() * 0.01
+
+# Randomly set the colors (valid values are between 0 and 1)
+for i in xrange(0, num_colors[0]):
+    colors[i] = random.random()
+
+# Now set the positions and colors for geometry 1 of link 0 of the fuze
+# bottle. Note that these functions are pretty slow, so use them sparingly.    
+camera.set_link_mesh_positions(fuze, positions, 0, 1)
+camera.set_link_mesh_colors(fuze, colors, 0, 1)
+
+# This is now a W x H x 3 numpy array filled with bytes
+img = camera.render()
+
+#You can plot the data if you want
+matplotlib.pyplot.imshow(img)
+
+pyplot.show();
+```
 
 ##Object Tracker Usage##
 

--- a/include/offscreen_render/RaveCamera.h
+++ b/include/offscreen_render/RaveCamera.h
@@ -21,12 +21,23 @@ namespace offscreen_render
             RaveCamera(OpenRAVE::EnvironmentBasePtr env);
             virtual ~RaveCamera();
 
+            // Sets the intrinsic parameters of the camera
             virtual void SetIntrinsics(float fx, float fy, float cx, float cy);
+            // Sets the width and height of the camera in pixels
             virtual void SetSize(int w, int h);
+            // Add a kinbody with the following color.
             virtual void AddKinBody(const std::string& name, float r, float g, float b);
+            // Remove a kinbody with the given name
             virtual void RemoveKinBody(const std::string& name);
+            // Remove all kinbodies
             virtual void ClearBodies();
+            // Initialize the graphics engine
             virtual bool Initialize();
+            // Gets the models associated with the given kinbody. Returns false if kinbody doesn't exist.
+            virtual bool GetModels(const std::string& name, std::vector<size_t>& models);
+            // Gets the mesh model associated with the given kinbody, link and geometry index.
+            // Returns false if no such model exists.
+            virtual bool GetModel(const std::string& name, int link, size_t* modelIdx);
 
             // Interface Commands
             bool _SetIntrinsics(std::ostream& out, std::istream& in);
@@ -34,6 +45,14 @@ namespace offscreen_render
             bool _AddKinBody(std::ostream& out, std::istream& in);
             bool _RemoveKinBody(std::ostream& out, std::istream& in);
             bool _ClearBodies(std::ostream& out, std::istream& in);
+            bool _GetKinbodyLinkMeshIDs(std::ostream& out, std::istream& in);
+            bool _GetNumLinkGeometries(std::ostream& out, std::istream& in);
+            bool _GetLinkMeshPositions(std::ostream& out, std::istream& in);
+            bool _GetLinkMeshColors(std::ostream& out, std::istream& in);
+            bool _GetLinkMeshIndices(std::ostream& out, std::istream& in);
+            bool _SetLinkMeshPositions(std::ostream& out, std::istream& in);
+            bool _SetLinkMeshColors(std::ostream& out, std::istream& in);
+            bool _SetLinkMeshIndices(std::ostream& out, std::istream& in);
 
             // Overrides SensorBase
             virtual int Configure(OpenRAVE::SensorBase::ConfigureCommand, bool blocking = false);
@@ -46,6 +65,28 @@ namespace offscreen_render
             virtual bool SimulationStep(OpenRAVE::dReal fTimeElapsed);
 
         protected:
+            template<typename T> void OutputBuffer(std::ostream& out, const std::vector<T>& buffer)
+            {
+                for(size_t i = 0; i < buffer.size(); i++)
+                {
+                    out << buffer[i];
+                    if (i < buffer.size() - 1)
+                    {
+                        out << " ";
+                    }
+                }
+            }
+
+            template<typename T> void InputBuffer(std::istream& in, std::vector<T>& buffer)
+            {
+                while (in.good())
+                {
+                    T f;
+                    in >> f;
+                    buffer.push_back(f);
+                }
+            }
+
             OpenRAVE::SensorBase::CameraGeomData* geomData;
             OpenRAVE::SensorBase::SensorGeometryPtr geometry;
             OpenRAVE::Transform transform;

--- a/src/offscreen_render/examples/advanced.py
+++ b/src/offscreen_render/examples/advanced.py
@@ -8,12 +8,25 @@ from matplotlib import pyplot
 from openravepy import *
 from offscreen_render import interface_wrapper
 from mpl_toolkits.mplot3d import Axes3D
+from catkin.find_in_workspaces import find_in_workspaces
 
 env = Environment() # create openrave environment
 
 # Load some objects and set them up in the environment
-env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/bowl.kinbody.xml')
-env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/fuze_bottle.kinbody.xml')
+bowl_path = find_in_workspaces(search_dirs=['share'],
+                      project="pr_ordata",
+                      path="data/objects/bowl.kinbody.xml",
+                      first_match_only=True)[0]
+
+fuze_bottle_path = find_in_workspaces(search_dirs=['share'],
+                      project="pr_ordata",
+                      path="data/objects/fuze_bottle.kinbody.xml",
+                      first_match_only=True)[0]
+
+env.Load(bowl_path)
+env.Load(fuze_bottle_path)
+
+
 bowl = env.GetKinBody('bowl')
 fuze = env.GetKinBody('fuze_bottle')
 

--- a/src/offscreen_render/examples/advanced.py
+++ b/src/offscreen_render/examples/advanced.py
@@ -1,0 +1,86 @@
+"""Loads up an environment, attaches a viewer, loads a scene, and renders 
+images using the advanced interface.
+"""
+import openravepy
+import matplotlib
+import random
+from matplotlib import pyplot
+from openravepy import *
+from offscreen_render import interface_wrapper
+from mpl_toolkits.mplot3d import Axes3D
+
+env = Environment() # create openrave environment
+
+# Load some objects and set them up in the environment
+env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/bowl.kinbody.xml')
+env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/fuze_bottle.kinbody.xml')
+bowl = env.GetKinBody('bowl')
+fuze = env.GetKinBody('fuze_bottle')
+
+# Set the object positions
+tf = fuze.GetTransform()
+tf[0:3, 3] = numpy.array([0.3, 0, 0.5])
+bowl.SetTransform(tf)
+
+# Position the camera
+tf[0:3, 3] = numpy.array([0.1, 0, -0.2])
+
+# Initialize the camera
+camera = interface_wrapper.SimCamera(env, transform=tf,
+                 fx=529, fy=525, cx=328, cy=267, near=0.01, far=10.0, 
+                 width=640, height=480)
+                 
+# Add the bodies to the camera renderer
+camera.add_body(fuze)
+camera.add_body(bowl)
+
+# Now we're going to query some values that the renderer is using
+# internally to render the objects. Each kinbody has some number of
+# links and some number of geometries for each link. This fuze bottle
+# has one link and two geometries per link. Apparently geometry 0 is empty
+# for the fuze bottle, and geometry 1 has the actual data. We just need
+# to pass in the link and geometry index to get the data associated with
+# this mesh. Note that the OpenRAVE collision meshes are used here,
+# not the visual meshes! Also note that these functions are pretty slow,
+# so use them sparingly.
+# Mesh positions are stored as a flat array of x, y, z values
+positions = camera.get_link_mesh_positions(fuze, 0, 1)
+# Mesh colors are stored as a flat array of r, g, b values
+colors = camera.get_link_mesh_colors(fuze, 0, 1)
+# The triangle index is a flat array of unsigned short values. Each group
+# of three values corresponds to a triangle in the mesh.
+indices = camera.get_link_mesh_indices(fuze, 0, 1)
+
+# Print the values to see what they are!
+print 'vertex position buffer: '
+print positions
+print 'vertex color buffer: '
+print colors
+print 'triangle index buffer: '
+print indices
+
+
+# Now we're going to randomize the positions and colors
+num_colors = colors.shape
+num_positions = positions.shape
+
+# Add 1 cm of random noise to the positions
+for i in xrange(0, num_positions[0]):
+    positions[i] += random.random() * 0.01
+
+# Randomly set the colors (valid values are between 0 and 1)
+for i in xrange(0, num_colors[0]):
+    colors[i] = random.random()
+
+# Now set the positions and colors for geometry 1 of link 0 of the fuze
+# bottle. Note that these functions are pretty slow, so use them sparingly.    
+camera.set_link_mesh_positions(fuze, positions, 0, 1)
+camera.set_link_mesh_colors(fuze, colors, 0, 1)
+
+# This is now a W x H x 3 numpy array filled with bytes
+img = camera.render()
+
+#You can plot the data if you want
+matplotlib.pyplot.imshow(img)
+
+pyplot.show();

--- a/src/offscreen_render/examples/occlusion_checker.py
+++ b/src/offscreen_render/examples/occlusion_checker.py
@@ -1,0 +1,49 @@
+"""Loads up an environment, attaches a viewer, loads a scene, and renders 
+an occlusion image.
+"""
+import openravepy
+import matplotlib
+from matplotlib import pyplot
+from openravepy import *
+
+env = Environment() # create openrave environment
+
+# Load some objects and set them up in the environment
+env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/bowl.kinbody.xml')
+env.Load('/home/mklingen/prdev/src/pr-ordata/data/objects/fuze_bottle.kinbody.xml')
+bowl = env.GetKinBody('bowl')
+fuze = env.GetKinBody('fuze_bottle')
+tf = fuze.GetTransform()
+tf[0:3, 3] = numpy.array([0.3, 0, 0.5])
+fuze.SetTransform(tf)
+
+# Create the sensor
+sensor = openravepy.RaveCreateSensor(env, 'offscreen_render_camera')
+# Set its intrinsics (fx, fy, cx, cy, near, far)
+sensor.SendCommand('setintrinsic 529 525 328 267 0.01 10')
+# And its resolution in pixels
+sensor.SendCommand('setdims 640 480')
+#Initialize the sensor. Right now the size of the sensor can't be changed after you do this.
+# It will also open up an annoying opengl window just to get context.
+sensor.Configure(openravepy.Sensor.ConfigureCommand.PowerOn)
+# Add bodies to render with the given (r, g, b) colors
+sensor.SendCommand('addbody bowl 255 0 0')
+sensor.SendCommand('addbody fuze_bottle 0 255 0')
+
+# You can also set the sensor's extrinsic transform
+tf[0:3, 3] = numpy.array([0.0, 0, -0.5])
+sensor.SetTransform(tf)
+
+# This is how you make it render a frame (the argument is meaningless)
+sensor.SimulationStep(0.01)
+
+# Copy data from OpenGL using the sensor interface
+data = sensor.GetSensorData();
+
+# This is now a W x H x 3 numpy array filled with bytes
+img = data.imagedata
+
+#You can plot the data if you want
+matplotlib.pyplot.imshow(img)
+
+pyplot.show();

--- a/src/offscreen_render/interface_wrapper.py
+++ b/src/offscreen_render/interface_wrapper.py
@@ -92,8 +92,8 @@ class SimCamera:
     
     def set_link_mesh_positions(self, body, colors, link_idx=0, geometry_idx=0):
         with self.lock:
-             """Given a kinbody, its link index, and geometry index, sets the positions
-                of its vertices (a flat array of (x, y, z) values)"""
+            """Given a kinbody, its link index, and geometry index, sets the positions
+               of its vertices (a flat array of (x, y, z) values)"""
             pos_string = ' '.join(['%.5f' % num for num in colors])
             return self.send_command('set_link_mesh_positions '+ body.GetName() + ' ' + str(link_idx) + ' ' + str(geometry_idx) + ' ' + pos_string);
     

--- a/src/offscreen_render/interface_wrapper.py
+++ b/src/offscreen_render/interface_wrapper.py
@@ -1,0 +1,130 @@
+import openravepy;
+import random;
+import time;
+from io import BytesIO
+import numpy as np;
+from threading import Timer, Lock
+
+class SimCamera:
+    """"Simulates a camera in OpenRAVE to do offscreen computations"""
+
+    def __init__(self, env, transform=None,
+                 fx=529, fy=525, cx=328, cy=267, near=0.01, far=10.0, 
+                 width=640, height=480):
+        """Initializes the camera with intrinsics fx, fy, cx, cy, with a near
+           and far plane (in meters) with width and height in pixels"""
+           
+        self.env = env;
+        self.lock = Lock()
+        self.camera = openravepy.RaveCreateSensor(env, 'offscreen_render_camera')
+        self.set_intrinsic(fx, fy, cx, cy, near, far, width, height)
+        self.camera.Configure(openravepy.Sensor.ConfigureCommand.PowerOn);
+        if (transform is None):
+            self.set_transform(numpy.eye(4))
+        else:
+            self.set_transform(transform)
+            
+    def render(self):
+        """Renders an image from the camera and returns as a numpy array"""
+        self.camera.SimulationStep(0.01)
+        return self.camera.GetSensorData().imagedata;
+
+    def set_transform(self, tf):
+        """Sets the position/orientation of the camera"""
+        self.camera.SetTransform(tf)
+    
+    def add_body(self, body, r=-1, g=-1, b=-1):
+        """Adds a kinbody with the given color in red, green, blue 0-255"""
+        with self.lock:
+            if (self.camera is None):
+                print "Error:no camera created yet. Can't add body";
+                return;
+
+            if (r is -1):
+                r = random.randint(0, 255);
+                g = random.randint(0, 255);
+                b = random.randint(0, 255);
+            self.send_command('addbody ' + body.GetName() + ' ' + str(r) +
+             ' ' + str(g) + ' ' + str(b))
+
+    def get_mesh_ids(self, body):
+        """Gets the mesh link ids associated with the given body"""
+        with self.lock:
+            return self.send_command('get_kinbody_link_mesh_ids ' + body.GetName())
+
+    def get_num_link_geometries(self, body, link_idx=0):
+        """Gets the number of link geometries associated with a given kinbody 
+           and link"""
+        with self.lock:
+            return self.send_command('get_num_link_geometries ' + body.GetName()
+             + ' ' + str(link_idx))
+             
+    def get_link_mesh_positions(self, body, link_idx=0, geometry_idx=0):
+        with self.lock:
+            """Gets the (x, y, z flat array) positions associated with the given kinbody,
+               link, and geometry"""
+            response = self.send_command('get_link_mesh_positions ' + body.GetName() + ' ' + str(link_idx) + ' ' + str(geometry_idx));
+            filehandle = BytesIO(response)
+            return np.loadtxt(filehandle)
+
+    def get_link_mesh_colors(self, body, link_idx=0, geometry_idx=0):
+        with self.lock:
+            """Gets the mesh colors (r, g, b) flat array associated with the given kinbody,
+                link, and geometry"""
+            response = self.send_command('get_link_mesh_colors ' + body.GetName() + ' ' + str(link_idx) + ' ' + str(geometry_idx));
+            filehandle = BytesIO(response)
+            return np.loadtxt(filehandle)
+            
+    def get_link_mesh_indices(self, body, link_idx=0, geometry_idx=0):
+        with self.lock:
+            """Gets the triangle indices (short array) associated with the given kinbody,
+            link and geometry"""
+            response = self.send_command('get_link_mesh_indices ' + body.GetName() + ' ' + str(link_idx) + ' ' + str(geometry_idx));
+            filehandle = BytesIO(response)
+            return np.loadtxt(filehandle)    
+                 
+    def set_link_mesh_colors(self, body, colors, link_idx=0, geometry_idx=0):
+        with self.lock:
+            """Given a kinbody, its link index, and geometry index, sets the colors
+               of that mesh (a flat array of (r, g, b) values)"""
+            colors_string = ' '.join(['%.5f' % num for num in colors])
+            return self.send_command('set_link_mesh_colors '+ body.GetName() + ' ' + str(link_idx) + ' ' + str(geometry_idx) + ' ' + colors_string);        
+    
+    def set_link_mesh_positions(self, body, colors, link_idx=0, geometry_idx=0):
+        with self.lock:
+             """Given a kinbody, its link index, and geometry index, sets the positions
+                of its vertices (a flat array of (x, y, z) values)"""
+            pos_string = ' '.join(['%.5f' % num for num in colors])
+            return self.send_command('set_link_mesh_positions '+ body.GetName() + ' ' + str(link_idx) + ' ' + str(geometry_idx) + ' ' + pos_string);
+    
+    def set_link_mesh_indices(self, body, colors, link_idx=0, geometry_idx=0):
+        with self.lock:
+            """Given a kinbody, its link index and geometry index, sets the triangle
+               index values (a flat array of 16-bit unsigned ints)"""
+            idx_string = ' '.join(['%.5f' % num for num in colors])
+            return self.send_command('set_link_mesh_indices '+ body.GetName() + ' ' + str(link_idx) + ' ' + str(geometry_idx) + ' ' + idx_string);
+    
+    def remove_body(self, body):
+        """Removes the given kinbody from the renderer"""
+        with self.lock:
+            if (self.camera is None):
+                print "Error:no camera created yet. Can't remove body";
+                return;
+            self.send_command('removebody ' + body.GetName())
+            
+    def clear_bodies(self):
+        """Clears all the bodies from the renderer"""
+        self.send_command('clearbodies')
+   
+    def set_intrinsic(self, fx, fy, cx, cy, near, far, width, height):
+        """Sets the camera intrinsic values"""
+        self.send_command('setintrinsic ' + 
+            str(fx) + ' ' + str(fy) + ' ' + str(cx) + 
+            ' ' + str(cy) + ' ' + str(near) + ' ' + str(far));
+        self.send_command('setdims ' + 
+        str(width) + ' ' + str(height));
+
+    def send_command(self, command):
+        #print command;
+        return self.camera.SendCommand(command);
+

--- a/src/offscreen_render/test_cpp.cpp
+++ b/src/offscreen_render/test_cpp.cpp
@@ -88,8 +88,9 @@ void DrawSceneFixed(float aspect)
 }
 
 using namespace offscreen_render;
-int main(void)
+int main(int argc, char** argv)
 {
+    ros::init(argc, argv, "test_offscreen_render");
     OpenRAVE::RaveInitialize(true);
     OpenRAVE::EnvironmentBasePtr environment = OpenRAVE::RaveCreateEnvironment();
     RaveCamera2ROS cam(environment);


### PR DESCRIPTION
Adds support for custom vertex coloring, custom vertex positions, and a custom index list. Essentially allows the user to create a completely custom model in python and have it drawn in `offscreen_render`. Also adds a much-simplified python interface in `interface_wrapper.py`.

![img](http://i.imgur.com/nCNkQWZ.png)
